### PR TITLE
fix cut top

### DIFF
--- a/www/css/mainStyle.css
+++ b/www/css/mainStyle.css
@@ -776,6 +776,7 @@ Desc section
   position: fixed;
   right: 0;
   bottom: 0;
+  top: 0;
   min-width: 100%;
   min-height: 100%;
 }


### PR DESCRIPTION
refer to #24 
it should fix the top being cut problem, but in some extreme resolution the video is smaller than the header, which makes a little white bar at the bottom of the header (it looks ok since the background is white and there is no text there)